### PR TITLE
update reactive-mongo to 0.3.0. Fixes #45

### DIFF
--- a/package.js
+++ b/package.js
@@ -20,7 +20,7 @@ Package.onUse(function (api) {
   // 3rd party dependencies.
   api.use([
     'peerlibrary:server-autorun@0.7.1',
-    'peerlibrary:reactive-mongo@0.2.2',
+    'peerlibrary:reactive-mongo@0.3.0',
     'peerlibrary:extend-publish@0.5.0'
   ], 'server');
 


### PR DESCRIPTION
To enable `ordered:false` so `findOne` works with oplog.