### PR TITLE
Fix #44: Meteor 1.8.1 - ReactiveVar is not defined

### DIFF
--- a/tests.coffee
+++ b/tests.coffee
@@ -1,3 +1,5 @@
+ReactiveVar = require 'meteor/reactive-var'
+
 for idGeneration in ['STRING', 'MONGO']
   do (idGeneration) ->
     allCollections = []

--- a/tests.coffee
+++ b/tests.coffee
@@ -1,4 +1,4 @@
-ReactiveVar = require 'meteor/reactive-var'
+{ ReactiveVar } = require 'meteor/reactive-var'
 
 for idGeneration in ['STRING', 'MONGO']
   do (idGeneration) ->


### PR DESCRIPTION
Fixes #44 - ReactiveVar is not imported in `tests.coffee`.  Causes server to fail when package is added to Meteor 1.8.1.